### PR TITLE
More fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,14 +3,14 @@ project('zlib', 'c', version : '1.2.11', license : 'zlib')
 cc = meson.get_compiler('c')
 
 link_args = []
+compile_args = []
 if cc.get_id() == 'msvc'
   add_project_arguments('-D_CRT_SECURE_NO_DEPRECATE',
     '-D_CRT_NONSTDC_NO_DEPRECATE', language : 'c')
 else
   # Don't spam consumers of this wrap with these warnings
-  args = cc.get_supported_arguments(['-Wno-implicit-fallthrough',
-                                     '-Wno-implicit-function-declaration'])
-  add_project_arguments(args, language : 'c')
+  compile_args += cc.get_supported_arguments(['-Wno-implicit-fallthrough',
+                                              '-Wno-implicit-function-declaration'])
   if cc.get_id() == 'gcc' and host_machine.system() != 'windows'
     vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
     link_args += [vflag]
@@ -45,9 +45,8 @@ if host_machine.system() == 'windows'
   src += win.compile_resources('win32/zlib1.rc', args : win_args)
 endif
 
-compile_args = []
 if get_option('solo')
-  compile_args = ['-DZ_SOLO']
+  compile_args += ['-DZ_SOLO']
 endif
 
 zlib = library('z', src,

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,15 @@ link_args = []
 if cc.get_id() == 'msvc'
   add_project_arguments('-D_CRT_SECURE_NO_DEPRECATE',
     '-D_CRT_NONSTDC_NO_DEPRECATE', language : 'c')
-elif cc.get_id() == 'gcc' and host_machine.system() != 'windows'
-  vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
-  link_args += [vflag]
+else
+  # Don't spam consumers of this wrap with these warnings
+  args = cc.get_supported_arguments(['-Wno-implicit-fallthrough',
+                                     '-Wno-implicit-function-declaration'])
+  add_project_arguments(args, language : 'c')
+  if cc.get_id() == 'gcc' and host_machine.system() != 'windows'
+    vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
+    link_args += [vflag]
+  endif
 endif
 
 src = files([

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,13 @@ if host_machine.system() == 'windows'
   src += win.compile_resources('win32/zlib1.rc', args : win_args)
 endif
 
+compile_args = []
+if get_option('solo')
+  compile_args = ['-DZ_SOLO']
+endif
+
 zlib = library('z', src,
+  c_args : compile_args,
   link_args : link_args,
   vs_module_defs : 'win32/zlib.def',
   install : true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('solo', type: 'boolean', value: false, description: 'Build a minimal zlib without file I/O API')


### PR DESCRIPTION
commit a5e198de784dd07f358dac8e40a9dcc9e93b1029:

Suppress warnings with gcc and clang

commit e045d9f1f9e108402c3874fd6c6050050527795e:

Add a new option for a more minimal build `-Dsolo=true`