### PR TITLE
zlib.net seems to have ceased to exist

### DIFF
--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
 directory = zlib-1.2.11
 
-source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_url = https://github.com/madler/zlib/archive/v1.2.11.tar.gz
 source_filename = zlib-1.2.11.tar.gz
-source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+source_hash = 629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff


### PR DESCRIPTION
But development seems to have shifted to github, so let's get the
sources from there instead.