### PR TITLE
Fix 0.49 deprecation warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,6 @@ install_headers(headers)
 
 pkg = import('pkgconfig')
 
-pkg.generate(name: 'zlib',
-             description: 'zlib compression library',
-             libraries: zlib)
+pkg.generate(zlib,
+             name: 'zlib',
+             description: 'zlib compression library')


### PR DESCRIPTION
@sarum9in this fixes
```
subprojects/zlib-1.2.11/meson.build:68: DEPRECATION: Library z
was passed to the "libraries" keyword argument of a previous call to
generate() method instead of first positional argument. Adding zlib
to "Requires" field, but this is a deprecated behaviour that will change
in a future version of Meson. Please report the issue if this warning
cannot be avoided in your case.
```