### PR TITLE
Windows build cleanup

### DIFF
--- a/LICENSE.build
+++ b/LICENSE.build
@@ -1,0 +1,19 @@
+Copyright (c) 2018 The Meson development team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,8 @@ link_args = []
 compile_args = []
 if cc.get_id() == 'msvc'
   add_project_arguments('-D_CRT_SECURE_NO_DEPRECATE',
-    '-D_CRT_NONSTDC_NO_DEPRECATE', language : 'c')
+    '-D_CRT_NONSTDC_NO_DEPRECATE',
+    '/wd4131', '/wd4244', '/wd4127', '/wd4245', '/wd4267', language : 'c')
 else
   # Don't spam consumers of this wrap with these warnings
   compile_args += cc.get_supported_arguments(['-Wno-implicit-fallthrough',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,26 @@
+project('zlib', 'c', version : '1.2.11', license : 'zlib')
+
+src = files([
+  'adler32.c',
+  'crc32.c',
+  'deflate.c',
+  'infback.c',
+  'inffast.c',
+  'inflate.c',
+  'inftrees.c',
+  'trees.c',
+  'zutil.c',
+  'compress.c',
+  'uncompr.c',
+  'gzclose.c',
+  'gzlib.c',
+  'gzread.c',
+  'gzwrite.c'])
+
+zlib = library('z', src)
+
+incdir = include_directories('.')
+
+zlib_dep = declare_dependency(
+  link_with : zlib,
+  include_directories : incdir)

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,6 @@ install_headers(headers)
 
 pkg = import('pkgconfig')
 
-pkg.generate(name: 'zlib',
-             description: 'zlib compression library',
-             libraries: zlib)
+pkg.generate(zlib,
+             name: 'zlib',
+             description: 'zlib compression library')

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,16 @@
 project('zlib', 'c', version : '1.2.11', license : 'zlib')
 
+cc = meson.get_compiler('c')
+
+link_args = []
+if cc.get_id() == 'msvc'
+  add_project_arguments('-D_CRT_SECURE_NO_DEPRECATE',
+    '-D_CRT_NONSTDC_NO_DEPRECATE', language : 'c')
+elif cc.get_id() == 'gcc' and host_machine.system() != 'windows'
+  vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
+  link_args += [vflag]
+endif
+
 src = files([
   'adler32.c',
   'crc32.c',
@@ -17,10 +28,32 @@ src = files([
   'gzread.c',
   'gzwrite.c'])
 
-zlib = library('z', src)
+headers = files(['zconf.h', 'zlib.h'])
+
+if host_machine.system() == 'windows'
+  win = import('windows')
+  win_args = []
+  if cc.get_id() != 'msvc'
+    win_args += '-DGCC_WINDRES'
+  endif
+  src += win.compile_resources('win32/zlib1.rc', args : win_args)
+endif
+
+zlib = library('z', src,
+  link_args : link_args,
+  vs_module_defs : 'win32/zlib.def',
+  install : true)
 
 incdir = include_directories('.')
 
 zlib_dep = declare_dependency(
   link_with : zlib,
   include_directories : incdir)
+
+install_headers(headers)
+
+pkg = import('pkgconfig')
+
+pkg.generate(name: 'zlib',
+             description: 'zlib compression library',
+             libraries: zlib)

--- a/meson.build
+++ b/meson.build
@@ -3,12 +3,18 @@ project('zlib', 'c', version : '1.2.11', license : 'zlib')
 cc = meson.get_compiler('c')
 
 link_args = []
+compile_args = []
 if cc.get_id() == 'msvc'
   add_project_arguments('-D_CRT_SECURE_NO_DEPRECATE',
     '-D_CRT_NONSTDC_NO_DEPRECATE', language : 'c')
-elif cc.get_id() == 'gcc' and host_machine.system() != 'windows'
-  vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
-  link_args += [vflag]
+else
+  # Don't spam consumers of this wrap with these warnings
+  compile_args += cc.get_supported_arguments(['-Wno-implicit-fallthrough',
+                                              '-Wno-implicit-function-declaration'])
+  if cc.get_id() == 'gcc' and host_machine.system() != 'windows'
+    vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
+    link_args += [vflag]
+  endif
 endif
 
 src = files([
@@ -39,7 +45,12 @@ if host_machine.system() == 'windows'
   src += win.compile_resources('win32/zlib1.rc', args : win_args)
 endif
 
+if get_option('solo')
+  compile_args += ['-DZ_SOLO']
+endif
+
 zlib = library('z', src,
+  c_args : compile_args,
   link_args : link_args,
   vs_module_defs : 'win32/zlib.def',
   install : true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('solo', type: 'boolean', value: false, description: 'Build a minimal zlib without file I/O API')

--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,3 @@
-This is a repository that provides Wrap packaging to Zlib. The exact
-format is not yet clear so this is flying at the seats of pants.
+This repository contains a Meson build definition for project zlib.
+
+For more information please see http://mesonbuild.com.

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = zlib-1.2.11
+
+source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -4,3 +4,7 @@ directory = zlib-1.2.11
 source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
 source_filename = zlib-1.2.11.tar.gz
 source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+[provide]
+
+zlib = zlib_dep


### PR DESCRIPTION
Cleanup warnings with Microsoft compiler

  Just add a few level-4 warnings desactivations for Microsoft compiler to
  prevent information spamming when built on Windows. This is particularly
  useful when building GLib on Windows for example.